### PR TITLE
Feature/finish appeal aggregate

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -1,11 +1,11 @@
 {
   "space:base": {
     "git":"https://github.com/meteor-space/base.git",
-    "branch": "fix/remaining-camel-case-api-changes"
+    "branch": "develop"
   },
   "space:messaging": {
     "git":"https://github.com/meteor-space/messaging.git",
-    "branch": "chore/update-to-camel-case-api"
+    "branch": "develop"
   },
   "space:event-sourcing": {
     "git":"https://github.com/meteor-space/event-sourcing.git",
@@ -17,6 +17,14 @@
   },
   "space:flux": {
     "git":"https://github.com/meteor-space/flux.git",
+    "branch": "develop"
+  },
+  "space:accounts": {
+    "git":"https://github.com/meteor-space/accounts.git",
+    "branch": "develop"
+  },
+  "space:accounts-ui": {
+    "git":"https://github.com/meteor-space/accounts-ui.git",
     "branch": "develop"
   },
   "space:testing": {

--- a/packages/base/source/server/commands.js
+++ b/packages/base/source/server/commands.js
@@ -37,6 +37,8 @@ Space.messaging.define(Space.messaging.Command, `Donations`, {
 
   FulfillPledge: {
     id: Guid
-  }
+  },
+
+  CloseAppeal: {}
 
 });

--- a/packages/base/source/server/commands.js
+++ b/packages/base/source/server/commands.js
@@ -39,7 +39,7 @@ Space.messaging.define(Space.messaging.Command, `Donations`, {
     id: Guid
   },
 
-  RenegOnPledge: {
+  WriteOffPledge: {
     id: Guid
   },
 

--- a/packages/base/source/server/commands.js
+++ b/packages/base/source/server/commands.js
@@ -31,6 +31,10 @@ Space.messaging.define(Space.messaging.Command, `Donations`, {
     pledgeId: Guid
   },
 
+  DeclinePledge: {
+    pledgeId: Guid
+  },
+
   FulfillPledge: {
     pledgeId: Guid
   }

--- a/packages/base/source/server/commands.js
+++ b/packages/base/source/server/commands.js
@@ -22,21 +22,21 @@ Space.messaging.define(Space.messaging.Command, `Donations`, {
   },
 
   MakePledge: {
-    pledgeId: Guid,
+    id: Guid,
+    donor: Donations.Contact,
     quantity: Quantity,
-    donor: Donations.Contact
   },
 
   AcceptPledge: {
-    pledgeId: Guid
+    id: Guid
   },
 
   DeclinePledge: {
-    pledgeId: Guid
+    id: Guid
   },
 
   FulfillPledge: {
-    pledgeId: Guid
+    id: Guid
   }
 
 });

--- a/packages/base/source/server/commands.js
+++ b/packages/base/source/server/commands.js
@@ -39,6 +39,10 @@ Space.messaging.define(Space.messaging.Command, `Donations`, {
     id: Guid
   },
 
+  RenegOnPledge: {
+    id: Guid
+  },
+
   CloseAppeal: {}
 
 });

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -11,8 +11,8 @@ Space.Error.extend(Donations, `AppealNotOpenToDeclinePledge`, {
   message: `Appeal not open to decline pledge.`
 });
 
-Space.Error.extend(Donations, `AppealNotOpenToRenegOnPledge`, {
-  message: `Appeal not open to reneg on pledge.`
+Space.Error.extend(Donations, `AppealNotOpenToWriteOffPledge`, {
+  message: `Appeal not open to write off pledge.`
 });
 
 Space.Error.extend(Donations, `PledgeHasToBeAcceptedBeforeFulfilled`, {
@@ -34,8 +34,8 @@ Space.Error.extend(Donations, `FulfilledPledgeCannotBeDeclined`, {
   message: `Fulfilled pledge cannot be declined`
 });
 
-Space.Error.extend(Donations, `FulfilledPledgeCannotBeReneged`, {
-  message: `Fulfilled pledge cannot be reneged`
+Space.Error.extend(Donations, `FulfilledPledgeCannotBeWrittenOff`, {
+  message: `Fulfilled pledge cannot be written off`
 });
 
 Space.Error.extend(Donations, `FulfilledAppealCannotBeClosed`, {

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -22,4 +22,6 @@ Space.Error.extend(Donations, `PledgeCannotBeDeclinedIfFulfilled`, {
   message: `Pledge cannot be declined if fulfilled`
 });
 
-
+Space.Error.extend(Donations, `FulfilledAppealCannotBeClosed`, {
+  message: `Fulfilled appeal cannot be closed`
+});

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -7,6 +7,10 @@ Space.Error.extend(Donations, `AppealNotOpenToAcceptPledge`, {
   message: `Appeal not open to accept pledge.`
 });
 
+Space.Error.extend(Donations, `AppealNotOpenToDeclinePledge`, {
+  message: `Appeal not open to decline pledge.`
+});
+
 Space.Error.extend(Donations, `PledgeHasToBeAcceptedBeforeFulfilled`, {
   message: `Pledge has to be accepted before it can be fulfilled.`
 });

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -1,10 +1,14 @@
 
-Space.Error.extend(Donations, `PledgeCannotBeMadeToFulfilledAppeal`, {
-  message: `A pledge cannot be made for a fulfilled appeal.`
+Space.Error.extend(Donations, `AppealNotOpenForNewPledges`, {
+  message: `Appeal not open for new pledges.`
+});
+
+Space.Error.extend(Donations, `AppealNotOpenToAcceptPledge`, {
+  message: `Appeal not open to accept pledge.`
 });
 
 Space.Error.extend(Donations, `PledgeHasToBeAcceptedBeforeFulfilled`, {
-  message: `A pledge has to be accepted before it can be fulfilled.`
+  message: `Pledge has to be accepted before it can be fulfilled.`
 });
 
 Space.Error.extend(Donations, `PledgeNotFoundError`, {
@@ -15,7 +19,7 @@ Space.Error.extend(Donations, `PledgeNotFoundError`, {
 });
 
 Space.Error.extend(Donations, `PledgeCannotBeDeclinedIfFulfilled`, {
-  message: `A pledge cannot be declined if already fulfilled.`
+  message: `Pledge cannot be declined if fulfilled`
 });
 
 

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -18,8 +18,12 @@ Space.Error.extend(Donations, `PledgeNotFoundError`, {
   }
 });
 
-Space.Error.extend(Donations, `PledgeCannotBeDeclinedIfFulfilled`, {
-  message: `Pledge cannot be declined if fulfilled`
+Space.Error.extend(Donations, `FulfilledPledgeCannotBeAccepted`, {
+  message: `Fulfilled pledge cannot be accepted`
+});
+
+Space.Error.extend(Donations, `FulfilledPledgeCannotBeDeclined`, {
+  message: `Fulfilled pledge cannot be declined`
 });
 
 Space.Error.extend(Donations, `FulfilledAppealCannotBeClosed`, {

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -13,3 +13,9 @@ Space.Error.extend(Donations, `PledgeNotFoundError`, {
     this.message = `No pledge with id ${pledgeId} found.`;
   }
 });
+
+Space.Error.extend(Donations, `PledgeCannotBeDeclinedIfFulfilled`, {
+  message: `A pledge cannot be declined if already fulfilled.`
+});
+
+

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -11,6 +11,10 @@ Space.Error.extend(Donations, `AppealNotOpenToDeclinePledge`, {
   message: `Appeal not open to decline pledge.`
 });
 
+Space.Error.extend(Donations, `AppealNotOpenToRenegOnPledge`, {
+  message: `Appeal not open to reneg on pledge.`
+});
+
 Space.Error.extend(Donations, `PledgeHasToBeAcceptedBeforeFulfilled`, {
   message: `Pledge has to be accepted before it can be fulfilled.`
 });
@@ -28,6 +32,10 @@ Space.Error.extend(Donations, `FulfilledPledgeCannotBeAccepted`, {
 
 Space.Error.extend(Donations, `FulfilledPledgeCannotBeDeclined`, {
   message: `Fulfilled pledge cannot be declined`
+});
+
+Space.Error.extend(Donations, `FulfilledPledgeCannotBeReneged`, {
+  message: `Fulfilled pledge cannot be reneged`
 });
 
 Space.Error.extend(Donations, `FulfilledAppealCannotBeClosed`, {

--- a/packages/base/source/server/events.js
+++ b/packages/base/source/server/events.js
@@ -51,6 +51,14 @@ Space.messaging.define(Space.messaging.Event, `Donations`, {
     id: Guid,
     donor: Donations.Contact,
     quantity: Quantity
+  },
+
+  AppealClosed: {
+    title: String,
+    requiredQuantity: Quantity,
+    organizationId: Guid,
+    locationId: Guid,
+    description: Match.Optional(String)
   }
 
 });

--- a/packages/base/source/server/events.js
+++ b/packages/base/source/server/events.js
@@ -53,6 +53,12 @@ Space.messaging.define(Space.messaging.Event, `Donations`, {
     quantity: Quantity
   },
 
+  PledgeReneged: {
+    id: Guid,
+    donor: Donations.Contact,
+    quantity: Quantity
+  },
+
   AppealClosed: {
     title: String,
     requiredQuantity: Quantity,

--- a/packages/base/source/server/events.js
+++ b/packages/base/source/server/events.js
@@ -22,23 +22,35 @@ Space.messaging.define(Space.messaging.Event, `Donations`, {
   },
 
   PledgeMade: {
-    pledgeId: Guid,
-    quantity: Quantity,
-    donor: Donations.Contact
+    id: Guid,
+    donor: Donations.Contact,
+    quantity: Quantity
   },
 
-  AppealFulfilled: {},
+  AppealFulfilled: {
+    title: String,
+    requiredQuantity: Quantity,
+    organizationId: Guid,
+    locationId: Guid,
+    description: Match.Optional(String)
+  },
 
   PledgeAccepted: {
-    pledgeId: Guid
+    id: Guid,
+    donor: Donations.Contact,
+    quantity: Quantity
   },
 
   PledgeDeclined: {
-    pledgeId: Guid
+    id: Guid,
+    donor: Donations.Contact,
+    quantity: Quantity
   },
 
   PledgeFulfilled: {
-    pledgeId: Guid
+    id: Guid,
+    donor: Donations.Contact,
+    quantity: Quantity
   }
 
 });

--- a/packages/base/source/server/events.js
+++ b/packages/base/source/server/events.js
@@ -53,7 +53,7 @@ Space.messaging.define(Space.messaging.Event, `Donations`, {
     quantity: Quantity
   },
 
-  PledgeReneged: {
+  PledgeWrittenOff: {
     id: Guid,
     donor: Donations.Contact,
     quantity: Quantity

--- a/packages/base/source/server/events.js
+++ b/packages/base/source/server/events.js
@@ -33,6 +33,10 @@ Space.messaging.define(Space.messaging.Event, `Donations`, {
     pledgeId: Guid
   },
 
+  PledgeDeclined: {
+    pledgeId: Guid
+  },
+
   PledgeFulfilled: {
     pledgeId: Guid
   }

--- a/packages/domain/source/server/appeals/appeal-router.js
+++ b/packages/domain/source/server/appeals/appeal-router.js
@@ -1,4 +1,4 @@
-Space.eventSourcing.Router.extend(Donations, `AppealRouter`, {
+Space.eventSourcing.AggregateRouter.extend(Donations, `AppealRouter`, {
 
   aggregate: Donations.Appeal,
   initializingCommand: Donations.MakeAppeal,

--- a/packages/domain/source/server/appeals/appeal-router.js
+++ b/packages/domain/source/server/appeals/appeal-router.js
@@ -8,6 +8,7 @@ Space.eventSourcing.AggregateRouter.extend(Donations, `AppealRouter`, {
     Donations.AcceptPledge,
     Donations.DeclinePledge,
     Donations.FulfillPledge,
+    Donations.RenegOnPledge,
     Donations.CloseAppeal
   ]
 

--- a/packages/domain/source/server/appeals/appeal-router.js
+++ b/packages/domain/source/server/appeals/appeal-router.js
@@ -6,6 +6,7 @@ Space.eventSourcing.AggregateRouter.extend(Donations, `AppealRouter`, {
   routeCommands: [
     Donations.MakePledge,
     Donations.AcceptPledge,
+    Donations.DeclinePledge,
     Donations.FulfillPledge
   ]
 

--- a/packages/domain/source/server/appeals/appeal-router.js
+++ b/packages/domain/source/server/appeals/appeal-router.js
@@ -8,7 +8,7 @@ Space.eventSourcing.AggregateRouter.extend(Donations, `AppealRouter`, {
     Donations.AcceptPledge,
     Donations.DeclinePledge,
     Donations.FulfillPledge,
-    Donations.RenegOnPledge,
+    Donations.WriteOffPledge,
     Donations.CloseAppeal
   ]
 

--- a/packages/domain/source/server/appeals/appeal-router.js
+++ b/packages/domain/source/server/appeals/appeal-router.js
@@ -7,7 +7,8 @@ Space.eventSourcing.AggregateRouter.extend(Donations, `AppealRouter`, {
     Donations.MakePledge,
     Donations.AcceptPledge,
     Donations.DeclinePledge,
-    Donations.FulfillPledge
+    Donations.FulfillPledge,
+    Donations.CloseAppeal
   ]
 
 });

--- a/packages/domain/source/server/appeals/appeal.js
+++ b/packages/domain/source/server/appeals/appeal.js
@@ -44,47 +44,51 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
   },
 
   _makePledge(command) {
-    if (this.hasState(this.STATES.open)) {
-      // Pledged quantity is capped at the appeal’s required quantity
-      let quantity = command.quantity;
-      let newPledgedQuantity = this.pledgedQuantity.add(quantity);
-      if (newPledgedQuantity.isMore(this.requiredQuantity)) {
-        quantity = quantity.substract(newPledgedQuantity.delta(this.requiredQuantity));
-        command.quantity = quantity; // Assign capped quantity
-      }
-      let pledgedQuantity = this.pledgedQuantity.add(quantity);
-      this.record(new Donations.PledgeMade(this._eventPropsFromCommand(command)));
-      // Fulfilled when the sum of pledged items equals the required quantity.
-      if (pledgedQuantity.equals(this.requiredQuantity)) {
-        this.record(new Donations.AppealFulfilled({
-          sourceId: this.getId(),
-          title: this.title,
-          requiredQuantity: this.requiredQuantity,
-          organizationId: this.organizationId,
-          locationId: this.locationId,
-          description: this.description
-        }));
-      }
-    } else {
+    if (!this.hasState(this.STATES.open)) {
       throw new Donations.AppealNotOpenForNewPledges();
+    }
+    // Pledged quantity is capped at the appeal’s required quantity
+    let quantity = command.quantity;
+    let newPledgedQuantity = this.pledgedQuantity.add(quantity);
+    if (newPledgedQuantity.isMore(this.requiredQuantity)) {
+      quantity = quantity.substract(newPledgedQuantity.delta(this.requiredQuantity));
+      command.quantity = quantity; // Assign capped quantity
+    }
+    let pledgedQuantity = this.pledgedQuantity.add(quantity);
+    this.record(new Donations.PledgeMade(this._eventPropsFromCommand(command)));
+    // Fulfilled when the sum of pledged items equals the required quantity.
+    if (pledgedQuantity.equals(this.requiredQuantity)) {
+      this.record(new Donations.AppealFulfilled({
+        sourceId: this.getId(),
+        title: this.title,
+        requiredQuantity: this.requiredQuantity,
+        organizationId: this.organizationId,
+        locationId: this.locationId,
+        description: this.description
+      }));
     }
   },
 
   _acceptPledge(command) {
-    if (this.hasState(this.STATES.open)) {
-      this.record(new Donations.PledgeAccepted(_.extend({sourceId: this.getId()}, this._getPledgeById(command.id).toPlainObject())));
-    } else {
+    if (!this.hasState(this.STATES.open)) {
       throw new Donations.AppealNotOpenToAcceptPledge();
     }
+    this.record(new Donations.PledgeAccepted(_.extend({ sourceId: this.getId() },
+      this._getPledgeById(command.id).toPlainObject()
+    )));
 
   },
 
   _declinePledge(command) {
-    this.record(new Donations.PledgeDeclined(_.extend({sourceId: this.getId()}, this._getPledgeById(command.id).toPlainObject())));
+    this.record(new Donations.PledgeDeclined(_.extend({ sourceId: this.getId() },
+      this._getPledgeById(command.id).toPlainObject()
+    )));
   },
 
   _fulfillPledge(command) {
-    this.record(new Donations.PledgeFulfilled(_.extend({sourceId: this.getId()}, this._getPledgeById(command.id).toPlainObject())));
+    this.record(new Donations.PledgeFulfilled(_.extend({ sourceId: this.getId() },
+      this._getPledgeById(command.id).toPlainObject()
+    )));
   },
 
   // ============= EVENT HANDLERS =============

--- a/packages/domain/source/server/appeals/appeal.js
+++ b/packages/domain/source/server/appeals/appeal.js
@@ -75,19 +75,30 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
     if (!this.hasState(this.STATES.open)) {
       throw new Donations.AppealNotOpenToAcceptPledge();
     }
+    let pledge = this._getPledgeById(command.id);
+    pledge.throwIfCannotBeAccepted();
     this.record(new Donations.PledgeAccepted(_.extend({ sourceId: this.getId() },
-      this._getPledgeById(command.id).toPlainObject()
+      pledge.toPlainObject()
     )));
-
   },
 
   _declinePledge(command) {
+    if (!this.hasState(this.STATES.open)) {
+      throw new Donations.AppealNotOpenToDeclinePledge();
+    }
+    let pledge = this._getPledgeById(command.id);
+    pledge.throwIfCannotBeDeclined();
     this.record(new Donations.PledgeDeclined(_.extend({ sourceId: this.getId() },
-      this._getPledgeById(command.id).toPlainObject()
+      pledge.toPlainObject()
     )));
   },
 
   _fulfillPledge(command) {
+    if (!this.hasState(this.STATES.open)) {
+      throw new Donations.AppealNotOpenToFulfillPledge();
+    }
+    let pledge = this._getPledgeById(command.id);
+    pledge.throwIfCannotBeFulfilled();
     this.record(new Donations.PledgeFulfilled(_.extend({ sourceId: this.getId() },
       this._getPledgeById(command.id).toPlainObject()
     )));

--- a/packages/domain/source/server/appeals/appeal.js
+++ b/packages/domain/source/server/appeals/appeal.js
@@ -23,7 +23,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
       'Donations.AcceptPledge': this._acceptPledge,
       'Donations.DeclinePledge': this._declinePledge,
       'Donations.FulfillPledge': this._fulfillPledge,
-      'Donations.RenegOnPledge': this._renegOnPledge,
+      'Donations.WriteOffPledge': this._writeOffPledge,
       'Donations.CloseAppeal': this._closeAppeal
     };
   },
@@ -35,7 +35,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
       'Donations.PledgeAccepted': this._onPledgeAccepted,
       'Donations.PledgeDeclined': this._onPledgeDeclined,
       'Donations.PledgeFulfilled': this._onPledgeFulfilled,
-      'Donations.PledgeReneged': this._onPledgeReneged,
+      'Donations.PledgeWrittenOff': this._onPledgeWrittenOff,
       'Donations.AppealFulfilled': this._onAppealFulfilled,
       'Donations.AppealClosed': this._onAppealClosed
     };
@@ -106,13 +106,13 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
     )));
   },
 
-  _renegOnPledge(command) {
+  _writeOffPledge(command) {
     if (!this.hasState(this.STATES.open)) {
-      throw new Donations.AppealNotOpenToRenegOnPledge();
+      throw new Donations.AppealNotOpenToWriteOffPledge();
     }
     let pledge = this._getPledgeById(command.id);
-    pledge.throwIfCannotBeReneged();
-    this.record(new Donations.PledgeReneged(_.extend({ sourceId: this.getId() },
+    pledge.throwIfCannotBeWrittenOff();
+    this.record(new Donations.PledgeWrittenOff(_.extend({ sourceId: this.getId() },
       this._getPledgeById(command.id).toPlainObject()
     )));
   },
@@ -165,8 +165,8 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
     this._getPledgeById(event.id).fulfill();
   },
 
-  _onPledgeReneged(event) {
-    this._getPledgeById(event.id).reneg();
+  _onPledgeWrittenOff(event) {
+    this._getPledgeById(event.id).writeOff();
   },
 
   _onAppealClosed(event) {

--- a/packages/domain/source/server/appeals/appeal.js
+++ b/packages/domain/source/server/appeals/appeal.js
@@ -22,7 +22,8 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
       'Donations.MakePledge': this._makePledge,
       'Donations.AcceptPledge': this._acceptPledge,
       'Donations.DeclinePledge': this._declinePledge,
-      'Donations.FulfillPledge': this._fulfillPledge
+      'Donations.FulfillPledge': this._fulfillPledge,
+      'Donations.CloseAppeal': this._closeAppeal
     };
   },
 
@@ -33,7 +34,8 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
       'Donations.PledgeAccepted': this._onPledgeAccepted,
       'Donations.PledgeDeclined': this._onPledgeDeclined,
       'Donations.PledgeFulfilled': this._onPledgeFulfilled,
-      'Donations.AppealFulfilled': this._onAppealFulfilled
+      'Donations.AppealFulfilled': this._onAppealFulfilled,
+      'Donations.AppealClosed': this._onAppealClosed
     };
   },
 
@@ -91,6 +93,20 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
     )));
   },
 
+  _closeAppeal(command) {
+    if (!this.hasState(this.STATES.open)) {
+      throw new Donations.FulfilledAppealCannotBeClosed();
+    }
+    this.record(new Donations.AppealClosed({
+      sourceId: this.getId(),
+      title: this.title,
+      requiredQuantity: this.requiredQuantity,
+      organizationId: this.organizationId,
+      locationId: this.locationId,
+      description: this.description
+    }));
+  },
+
   // ============= EVENT HANDLERS =============
 
   _onAppealMade(event) {
@@ -123,6 +139,10 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _onPledgeFulfilled(event) {
     this._getPledgeById(event.id).fulfill();
+  },
+
+  _onAppealClosed(event) {
+    this._state = this.STATES.closed;
   },
 
   // =========== PRIVATE HELPERS ===========

--- a/packages/domain/source/server/appeals/appeal.js
+++ b/packages/domain/source/server/appeals/appeal.js
@@ -21,6 +21,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
       'Donations.MakeAppeal': this._makeAppeal,
       'Donations.MakePledge': this._makePledge,
       'Donations.AcceptPledge': this._acceptPledge,
+      'Donations.DeclinePledge': this._declinePledge,
       'Donations.FulfillPledge': this._fulfillPledge
     };
   },
@@ -29,9 +30,10 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
     return {
       'Donations.AppealMade': this._onAppealMade,
       'Donations.PledgeMade': this._onPledgeMade,
-      'Donations.AppealFulfilled': this._onAppealFulfilled,
       'Donations.PledgeAccepted': this._onPledgeAccepted,
-      'Donations.PledgeFulfilled': this._onPledgeFulfilled
+      'Donations.PledgeDeclined': this._onPledgeDeclined,
+      'Donations.PledgeFulfilled': this._onPledgeFulfilled,
+      'Donations.AppealFulfilled': this._onAppealFulfilled
     };
   },
 
@@ -65,6 +67,10 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
     this.record(new Donations.PledgeAccepted(this._eventPropsFromCommand(command)));
   },
 
+  _declinePledge(command) {
+    this.record(new Donations.PledgeDeclined(this._eventPropsFromCommand(command)));
+  },
+
   _fulfillPledge(command) {
     this.record(new Donations.PledgeFulfilled(this._eventPropsFromCommand(command)));
   },
@@ -89,6 +95,10 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _onPledgeAccepted(event) {
     this._getPledgeById(event.pledgeId).accept();
+  },
+
+  _onPledgeDeclined(event) {
+    this._getPledgeById(event.pledgeId).decline();
   },
 
   _onPledgeFulfilled(event) {

--- a/packages/domain/source/server/appeals/pledge.js
+++ b/packages/domain/source/server/appeals/pledge.js
@@ -20,24 +20,36 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
     this._state = this.STATES.new;
   },
 
-  accept() {
-    if (this._state === this.STATES.fulfilled) {
+  throwIfCannotBeAccepted() {
+    if (this._state === 'fulfilled') {
       throw new Donations.FulfilledPledgeCannotBeAccepted();
     }
+  },
+
+  throwIfCannotBeDeclined() {
+    if (this._state === 'fulfilled') {
+      throw new Donations.FulfilledPledgeCannotBeDeclined();
+    }
+  },
+
+  throwIfCannotBeFulfilled() {
+    if (this._state !== 'accepted') {
+      throw new Donations.PledgeHasToBeAcceptedBeforeFulfilled();
+    }
+  },
+
+  accept() {
+    this.throwIfCannotBeAccepted();
     this._state = this.STATES.accepted;
   },
 
   decline() {
-    if (this._state === this.STATES.fulfilled) {
-      throw new Donations.FulfilledPledgeCannotBeDeclined();
-    }
+    this.throwIfCannotBeDeclined();
     this._state = this.STATES.declined;
   },
 
   fulfill() {
-    if (this._state !== this.STATES.accepted) {
-      throw new Donations.PledgeHasToBeAcceptedBeforeFulfilled();
-    }
+    this.throwIfCannotBeFulfilled();
     this._state = this.STATES.fulfilled;
   }
 

--- a/packages/domain/source/server/appeals/pledge.js
+++ b/packages/domain/source/server/appeals/pledge.js
@@ -5,7 +5,7 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
     accepted: `accepted`,
     declined: `declined`,
     fulfilled: `fulfilled`,
-    reneged: 'reneged'
+    writtenOff: 'writtenOff'
   },
 
   fields() {
@@ -39,9 +39,9 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
     }
   },
 
-  throwIfCannotBeReneged() {
+  throwIfCannotBeWrittenOff() {
     if (this._state === 'fulfilled') {
-      throw new Donations.FulfilledPledgeCannotBeReneged();
+      throw new Donations.FulfilledPledgeCannotBeWrittenOff();
     }
   },
 
@@ -60,9 +60,9 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
     this._state = this.STATES.fulfilled;
   },
 
-  reneg() {
-    this.throwIfCannotBeReneged();
-    this._state = this.STATES.reneged;
+  writeOff() {
+    this.throwIfCannotBeWrittenOff();
+    this._state = this.STATES.writtenOff;
   }
 
 });

--- a/packages/domain/source/server/appeals/pledge.js
+++ b/packages/domain/source/server/appeals/pledge.js
@@ -3,6 +3,7 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
   STATES: {
     made: `made`,
     accepted: `accepted`,
+    declined: `declined`,
     fulfilled: `fulfilled`
   },
 
@@ -13,6 +14,13 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
 
   accept() {
     this._state = this.STATES.accepted;
+  },
+
+  decline() {
+    if (this._state === this.STATES.fulfilled) {
+      throw new Donations.PledgeCannotBeDeclinedIfFulfilled();
+    }
+    this._state = this.STATES.declined;
   },
 
   fulfill() {

--- a/packages/domain/source/server/appeals/pledge.js
+++ b/packages/domain/source/server/appeals/pledge.js
@@ -4,7 +4,8 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
     new: `new`,
     accepted: `accepted`,
     declined: `declined`,
-    fulfilled: `fulfilled`
+    fulfilled: `fulfilled`,
+    reneged: 'reneged'
   },
 
   fields() {
@@ -38,6 +39,12 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
     }
   },
 
+  throwIfCannotBeReneged() {
+    if (this._state === 'fulfilled') {
+      throw new Donations.FulfilledPledgeCannotBeReneged();
+    }
+  },
+
   accept() {
     this.throwIfCannotBeAccepted();
     this._state = this.STATES.accepted;
@@ -51,6 +58,11 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
   fulfill() {
     this.throwIfCannotBeFulfilled();
     this._state = this.STATES.fulfilled;
+  },
+
+  reneg() {
+    this.throwIfCannotBeReneged();
+    this._state = this.STATES.reneged;
   }
 
 });

--- a/packages/domain/source/server/appeals/pledge.js
+++ b/packages/domain/source/server/appeals/pledge.js
@@ -1,7 +1,7 @@
 Space.domain.Entity.extend(Donations, 'Pledge', {
 
   STATES: {
-    made: `made`,
+    new: `new`,
     accepted: `accepted`,
     declined: `declined`,
     fulfilled: `fulfilled`
@@ -17,16 +17,19 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
 
   Constructor(data) {
     Space.domain.Entity.call(this, data);
-    this._state = this.STATES.made;
+    this._state = this.STATES.new;
   },
 
   accept() {
+    if (this._state === this.STATES.fulfilled) {
+      throw new Donations.FulfilledPledgeCannotBeAccepted();
+    }
     this._state = this.STATES.accepted;
   },
 
   decline() {
     if (this._state === this.STATES.fulfilled) {
-      throw new Donations.PledgeCannotBeDeclinedIfFulfilled();
+      throw new Donations.FulfilledPledgeCannotBeDeclined();
     }
     this._state = this.STATES.declined;
   },

--- a/packages/domain/source/server/appeals/pledge.js
+++ b/packages/domain/source/server/appeals/pledge.js
@@ -7,6 +7,14 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
     fulfilled: `fulfilled`
   },
 
+  fields() {
+    return {
+      id: Guid,
+      donor: Donations.Contact,
+      quantity: Quantity
+    };
+  },
+
   Constructor(data) {
     Space.domain.Entity.call(this, data);
     this._state = this.STATES.made;
@@ -29,6 +37,7 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
     }
     this._state = this.STATES.fulfilled;
   }
+
 });
 
 Donations.Pledge.type('Donations.Pledge');

--- a/packages/domain/source/server/locations/location-router.js
+++ b/packages/domain/source/server/locations/location-router.js
@@ -1,4 +1,4 @@
-Space.eventSourcing.Router.extend(Donations, `LocationRouter`, {
+Space.eventSourcing.AggregateRouter.extend(Donations, `LocationRouter`, {
 
   aggregate: Donations.Location,
   initializingCommand: Donations.AddLocation

--- a/packages/domain/source/server/organizations/organization-router.js
+++ b/packages/domain/source/server/organizations/organization-router.js
@@ -1,4 +1,4 @@
-Space.eventSourcing.Router.extend(Donations, `OrganizationRouter`, {
+Space.eventSourcing.AggregateRouter.extend(Donations, `OrganizationRouter`, {
 
   aggregate: Donations.Organization,
   initializingCommand: Donations.CreateOrganization

--- a/packages/domain/source/server/organizations/organization.js
+++ b/packages/domain/source/server/organizations/organization.js
@@ -1,6 +1,6 @@
 Space.eventSourcing.Aggregate.extend(Donations, `Organization`, {
 
-  Fields: {
+  fields: {
     name: String,
     country: Country,
     contact: Donations.Contact

--- a/packages/domain/tests/appeals/appeal.tests.js
+++ b/packages/domain/tests/appeals/appeal.tests.js
@@ -338,6 +338,44 @@ describe(`Donations.Appeal`, function() {
       });
 
     });
+
+    describe(`regeged pledges`, function() {
+
+      it("publishes pledge reneged event", function() {
+
+        Donations.domain.test(Donations.Appeal)
+          .given(appealWithPledgeMade.call(this))
+          .when([
+            new Donations.RenegOnPledge({
+              targetId: this.appealId,
+              id: this.pledgeData.id
+            })
+          ])
+          .expect([
+            new Donations.PledgeReneged(_.extend({}, this.pledgeData, {
+              sourceId: this.appealId,
+              version: 2
+            }))
+          ]);
+
+      });
+
+      it(`cannot reneg on if already fulfilled`, function() {
+
+        Donations.domain.test(Donations.Appeal)
+          .given(appealWithFulfilledPledge.call(this))
+          .when([
+            new Donations.RenegOnPledge({
+              targetId: this.appealId,
+              id: this.pledgeData.id
+            })
+          ])
+          .expectToFailWith(new Donations.FulfilledPledgeCannotBeReneged());
+
+      });
+
+    });
+
   });
 
   describe(`closing an appeal`, function () {

--- a/packages/domain/tests/appeals/appeal.tests.js
+++ b/packages/domain/tests/appeals/appeal.tests.js
@@ -45,18 +45,18 @@ describe(`Donations.Appeal`, function() {
     ];
   };
 
-  //let closedAppeal = function () {
-  //  return [
-  //    new Donations.AppealMade(_.extend({}, this.appealData, {
-  //      sourceId: this.appealId,
-  //      version: 1
-  //    })),
-  //    new Donations.AppealClosed(_.extend({}, this.appealData, {
-  //      sourceId: this.appealId,
-  //      version: 2
-  //    }))
-  //  ];
-  //};
+  let closedAppeal = function () {
+    return [
+      new Donations.AppealMade(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 1
+      })),
+      new Donations.AppealClosed(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 2
+      }))
+    ];
+  };
 
   let appealWithPledgeMade = function () {
     return [
@@ -214,14 +214,14 @@ describe(`Donations.Appeal`, function() {
         )
         .expectToFailWith(new Donations.AppealNotOpenForNewPledges());
 
-      //Donations.domain.test(Donations.Appeal)
-      //  .given(closedAppeal.call(this))
-      //  .when(
-      //    new Donations.MakePledge(_.extend({}, this.pledgeData, {
-      //      targetId: this.appealId,
-      //    }))
-      //  )
-      //  .expectToFailWith(new Donations.AppealNotOpenForNewPledges());
+      Donations.domain.test(Donations.Appeal)
+        .given(closedAppeal.call(this))
+        .when(
+          new Donations.MakePledge(_.extend({}, this.pledgeData, {
+            targetId: this.appealId,
+          }))
+        )
+        .expectToFailWith(new Donations.AppealNotOpenForNewPledges());
 
     });
 
@@ -339,4 +339,49 @@ describe(`Donations.Appeal`, function() {
 
     });
   });
+
+  describe(`closing an appeal`, function () {
+
+    it(`closes an open appeal when commanded`, function () {
+
+      Donations.domain.test(Donations.Appeal)
+        .given(openAppeal.call(this))
+        .when(
+          new Donations.CloseAppeal({
+            targetId: this.appealId
+          })
+        )
+        .expect([
+          new Donations.AppealClosed(_.extend({}, this.appealData, {
+            sourceId: this.appealId,
+            version: 2,
+          }))
+        ]);
+
+    });
+
+    it(`throws an error if commanded to close a fulfilled or presently closed appeal`, function () {
+
+      Donations.domain.test(Donations.Appeal)
+        .given(fulfilledAppeal.call(this))
+        .when(
+          new Donations.CloseAppeal({
+            targetId: this.appealId
+          })
+        )
+        .expectToFailWith(new Donations.FulfilledAppealCannotBeClosed());
+
+      Donations.domain.test(Donations.Appeal)
+        .given(closedAppeal.call(this))
+        .when(
+          new Donations.CloseAppeal({
+            targetId: this.appealId
+          })
+        )
+        .expectToFailWith(new Donations.FulfilledAppealCannotBeClosed());
+
+    });
+
+  });
+
 });

--- a/packages/domain/tests/appeals/appeal.tests.js
+++ b/packages/domain/tests/appeals/appeal.tests.js
@@ -333,7 +333,7 @@ describe(`Donations.Appeal`, function() {
               id: this.pledgeData.id
             })
           ])
-          .expectToFailWith(new Donations.PledgeCannotBeDeclinedIfFulfilled());
+          .expectToFailWith(new Donations.FulfilledPledgeCannotBeDeclined());
 
       });
 

--- a/packages/domain/tests/appeals/appeal.tests.js
+++ b/packages/domain/tests/appeals/appeal.tests.js
@@ -339,20 +339,20 @@ describe(`Donations.Appeal`, function() {
 
     });
 
-    describe(`regeged pledges`, function() {
+    describe(`writing off pledges`, function() {
 
-      it("publishes pledge reneged event", function() {
+      it("publishes pledge written off event", function() {
 
         Donations.domain.test(Donations.Appeal)
           .given(appealWithPledgeMade.call(this))
           .when([
-            new Donations.RenegOnPledge({
+            new Donations.WriteOffPledge({
               targetId: this.appealId,
               id: this.pledgeData.id
             })
           ])
           .expect([
-            new Donations.PledgeReneged(_.extend({}, this.pledgeData, {
+            new Donations.PledgeWrittenOff(_.extend({}, this.pledgeData, {
               sourceId: this.appealId,
               version: 2
             }))
@@ -360,17 +360,17 @@ describe(`Donations.Appeal`, function() {
 
       });
 
-      it(`cannot reneg on if already fulfilled`, function() {
+      it(`cannot write off if already fulfilled`, function() {
 
         Donations.domain.test(Donations.Appeal)
           .given(appealWithFulfilledPledge.call(this))
           .when([
-            new Donations.RenegOnPledge({
+            new Donations.WriteOffPledge({
               targetId: this.appealId,
               id: this.pledgeData.id
             })
           ])
-          .expectToFailWith(new Donations.FulfilledPledgeCannotBeReneged());
+          .expectToFailWith(new Donations.FulfilledPledgeCannotBeWrittenOff());
 
       });
 


### PR DESCRIPTION
- reverses state check logic to target state when it makes sense
- rename `pledgeId` in pledge messages to `id`
- add appeal props to `AppealFulfilled` for richer projection capability
- add pledge props to pledge events for richer projection capability
- new error `AppealNotOpenToAcceptPledge`
- rename errors be more expressive
- tests reorganised to be more expressive

Todo:
- [x] Add `closed` concept
- [x] Rename first state of Pledge from `made` to `new` or similar. Pledges are still _made_ but that's an event, not a state.
- [x] Add `write off` pledge state and handling
