### PR TITLE
Add concept of draft and cancelled appeal

### DIFF
--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -1,24 +1,8 @@
 Space.Error.extend(Donations, `InvalidAppealState`, {
-  Constructor(currentState, commandedState) {
+  Constructor(commandName, currentState) {
     Space.Error.constructor.call(this);
-    this.message = `Appeal cannot move to ${commandedState} from the state of ${currentState}`;
+    this.message = `Cannot ${commandName} when in ${currentState} state`;
   }
-});
-
-Space.Error.extend(Donations, `AppealNotOpenForNewPledges`, {
-  message: `Appeal not open for new pledges.`
-});
-
-Space.Error.extend(Donations, `AppealNotOpenToAcceptPledge`, {
-  message: `Appeal not open to accept pledge.`
-});
-
-Space.Error.extend(Donations, `AppealNotOpenToDeclinePledge`, {
-  message: `Appeal not open to decline pledge.`
-});
-
-Space.Error.extend(Donations, `AppealNotOpenToWriteOffPledge`, {
-  message: `Appeal not open to write off pledge.`
 });
 
 Space.Error.extend(Donations, `PledgeHasToBeAcceptedBeforeFulfilled`, {
@@ -42,8 +26,4 @@ Space.Error.extend(Donations, `FulfilledPledgeCannotBeDeclined`, {
 
 Space.Error.extend(Donations, `FulfilledPledgeCannotBeWrittenOff`, {
   message: `Fulfilled pledge cannot be written off`
-});
-
-Space.Error.extend(Donations, `FulfilledAppealCannotBeClosed`, {
-  message: `Fulfilled appeal cannot be closed`
-});
+})

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -1,3 +1,9 @@
+Space.Error.extend(Donations, `InvalidAppealState`, {
+  Constructor(currentState, commandedState) {
+    Space.Error.constructor.call(this);
+    this.message = `Appeal cannot move to ${commandedState} from the state of ${currentState}`;
+  }
+});
 
 Space.Error.extend(Donations, `AppealNotOpenForNewPledges`, {
   message: `Appeal not open for new pledges.`

--- a/packages/base/source/server/errors.js
+++ b/packages/base/source/server/errors.js
@@ -5,8 +5,11 @@ Space.Error.extend(Donations, `InvalidAppealState`, {
   }
 });
 
-Space.Error.extend(Donations, `PledgeHasToBeAcceptedBeforeFulfilled`, {
-  message: `Pledge has to be accepted before it can be fulfilled.`
+Space.Error.extend(Donations, `InvalidPledgeState`, {
+  Constructor(commandName, currentState) {
+    Space.Error.constructor.call(this);
+    this.message = `Cannot ${commandName} when in ${currentState} state`;
+  }
 });
 
 Space.Error.extend(Donations, `PledgeNotFoundError`, {
@@ -15,15 +18,3 @@ Space.Error.extend(Donations, `PledgeNotFoundError`, {
     this.message = `No pledge with id ${pledgeId} found.`;
   }
 });
-
-Space.Error.extend(Donations, `FulfilledPledgeCannotBeAccepted`, {
-  message: `Fulfilled pledge cannot be accepted`
-});
-
-Space.Error.extend(Donations, `FulfilledPledgeCannotBeDeclined`, {
-  message: `Fulfilled pledge cannot be declined`
-});
-
-Space.Error.extend(Donations, `FulfilledPledgeCannotBeWrittenOff`, {
-  message: `Fulfilled pledge cannot be written off`
-})

--- a/packages/base/source/server/events.js
+++ b/packages/base/source/server/events.js
@@ -57,7 +57,23 @@ Space.messaging.define(Space.messaging.Event, `Donations`, {
 
   // APPEALS
 
+  AppealDrafted: {
+    title: String,
+    requiredQuantity: Quantity,
+    organizationId: Guid,
+    locationId: Guid,
+    description: Match.Optional(String)
+  },
+
   AppealMade: {
+    title: String,
+    requiredQuantity: Quantity,
+    organizationId: Guid,
+    locationId: Guid,
+    description: Match.Optional(String)
+  },
+
+  AppealCancelled: {
     title: String,
     requiredQuantity: Quantity,
     organizationId: Guid,

--- a/packages/base/source/shared/api-commands.js
+++ b/packages/base/source/shared/api-commands.js
@@ -26,12 +26,16 @@ Space.messaging.define(Space.messaging.Command, `Donations`, {
 
   // APPEALS
 
-  MakeAppeal: {
+  DraftAppeal: {
     title: String,
     requiredQuantity: Quantity,
     organizationId: Guid,
     locationId: Guid,
     description: Match.Optional(String)
-  }
+  },
+
+  MakeAppeal: {},
+
+  CancelAppeal: {}
 
 });

--- a/packages/domain/source/server/appeals/appeal-router.js
+++ b/packages/domain/source/server/appeals/appeal-router.js
@@ -1,9 +1,11 @@
 Space.eventSourcing.Router.extend(Donations, `AppealRouter`, {
 
   eventSourceable: Donations.Appeal,
-  initializingMessage: Donations.MakeAppeal,
+  initializingMessage: Donations.DraftAppeal,
 
   routeCommands: [
+    Donations.CancelAppeal,
+    Donations.MakeAppeal,
     Donations.MakePledge,
     Donations.AcceptPledge,
     Donations.DeclinePledge,

--- a/packages/domain/source/server/appeals/appeal.js
+++ b/packages/domain/source/server/appeals/appeal.js
@@ -57,7 +57,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _cancelAppeal(command) {
     if (!this.hasState(this.STATES.draft)) {
-      throw new Donations.InvalidAppealState(this._state, this.STATES.cancelled);
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
     }
     this.record(new Donations.AppealCancelled({
       sourceId: this.getId(),
@@ -71,7 +71,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _makeAppeal(command) {
     if (!this.hasState(this.STATES.draft)) {
-      throw new Donations.InvalidAppealState(this._state, this.STATES.open);
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
     }
     this.record(new Donations.AppealMade({
       sourceId: this.getId(),
@@ -85,7 +85,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _makePledge(command) {
     if (!this.hasState(this.STATES.open)) {
-      throw new Donations.AppealNotOpenForNewPledges();
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
     }
     // Pledged quantity is capped at the appeal’s required quantity
     let quantity = command.quantity;
@@ -111,7 +111,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _acceptPledge(command) {
     if (!this.hasState(this.STATES.open)) {
-      throw new Donations.AppealNotOpenToAcceptPledge();
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
     }
     let pledge = this._getPledgeById(command.id);
     pledge.throwIfCannotBeAccepted();
@@ -122,7 +122,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _declinePledge(command) {
     if (!this.hasState(this.STATES.open)) {
-      throw new Donations.AppealNotOpenToDeclinePledge();
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
     }
     let pledge = this._getPledgeById(command.id);
     pledge.throwIfCannotBeDeclined();
@@ -133,7 +133,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _fulfillPledge(command) {
     if (!this.hasState(this.STATES.open)) {
-      throw new Donations.AppealNotOpenToFulfillPledge();
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
     }
     let pledge = this._getPledgeById(command.id);
     pledge.throwIfCannotBeFulfilled();
@@ -144,7 +144,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _writeOffPledge(command) {
     if (!this.hasState(this.STATES.open)) {
-      throw new Donations.AppealNotOpenToWriteOffPledge();
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
     }
     let pledge = this._getPledgeById(command.id);
     pledge.throwIfCannotBeWrittenOff();
@@ -155,7 +155,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _closeAppeal(command) {
     if (!this.hasState(this.STATES.open)) {
-      throw new Donations.FulfilledAppealCannotBeClosed();
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
     }
     this.record(new Donations.AppealClosed({
       sourceId: this.getId(),

--- a/packages/domain/source/server/appeals/pledge.js
+++ b/packages/domain/source/server/appeals/pledge.js
@@ -23,25 +23,25 @@ Space.domain.Entity.extend(Donations, 'Pledge', {
 
   throwIfCannotBeAccepted() {
     if (this._state === 'fulfilled') {
-      throw new Donations.FulfilledPledgeCannotBeAccepted();
+      throw new Donations.InvalidPledgeState('AcceptPledge', this._state);
     }
   },
 
   throwIfCannotBeDeclined() {
     if (this._state === 'fulfilled') {
-      throw new Donations.FulfilledPledgeCannotBeDeclined();
+      throw new Donations.InvalidPledgeState('DeclinePledge', this._state);
     }
   },
 
   throwIfCannotBeFulfilled() {
     if (this._state !== 'accepted') {
-      throw new Donations.PledgeHasToBeAcceptedBeforeFulfilled();
+      throw new Donations.InvalidPledgeState('FulfillPledge', this._state);
     }
   },
 
   throwIfCannotBeWrittenOff() {
     if (this._state === 'fulfilled') {
-      throw new Donations.FulfilledPledgeCannotBeWrittenOff();
+      throw new Donations.InvalidPledgeState('WriteOffPledge', this._state);
     }
   },
 

--- a/packages/domain/tests/appeals/appeal.tests.js
+++ b/packages/domain/tests/appeals/appeal.tests.js
@@ -23,108 +23,248 @@ describe(`Donations.Appeal`, function() {
 
   });
 
-  let openAppeal = function () {
+  let draftAppeal = function () {
     return [
-      new Donations.AppealMade(_.extend({}, this.appealData, {
+      new Donations.AppealDrafted(_.extend({}, this.appealData, {
         sourceId: this.appealId,
         version: 1
+      }))
+    ];
+  };
+
+  let openAppeal = function () {
+    return [
+      new Donations.AppealDrafted(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 1
+      })),
+      new Donations.AppealMade(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 2
+      }))
+    ];
+  };
+
+  let cancelledAppeal = function () {
+    return [
+      new Donations.AppealDrafted(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 1
+      })),
+      new Donations.AppealCancelled(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 2
       }))
     ];
   };
 
   let fulfilledAppeal = function () {
     return [
-      new Donations.AppealMade(_.extend({}, this.appealData, {
+      new Donations.AppealDrafted(_.extend({}, this.appealData, {
         sourceId: this.appealId,
         version: 1
       })),
-      new Donations.AppealFulfilled(_.extend({}, this.appealData, {
+      new Donations.AppealMade(_.extend({}, this.appealData, {
         sourceId: this.appealId,
         version: 2
+      })),
+      new Donations.AppealFulfilled(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 3
       }))
     ];
   };
 
   let closedAppeal = function () {
     return [
-      new Donations.AppealMade(_.extend({}, this.appealData, {
+      new Donations.AppealDrafted(_.extend({}, this.appealData, {
         sourceId: this.appealId,
         version: 1
       })),
-      new Donations.AppealClosed(_.extend({}, this.appealData, {
+      new Donations.AppealMade(_.extend({}, this.appealData, {
         sourceId: this.appealId,
         version: 2
+      })),
+      new Donations.AppealClosed(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 3
       }))
     ];
   };
 
   let appealWithPledgeMade = function () {
     return [
-      new Donations.AppealMade(_.extend({}, this.appealData, {
+      new Donations.AppealDrafted(_.extend({}, this.appealData, {
         sourceId: this.appealId,
         version: 1
       })),
-      new Donations.PledgeMade(_.extend({}, this.pledgeData, {
+      new Donations.AppealMade(_.extend({}, this.appealData, {
         sourceId: this.appealId,
         version: 2
+      })),
+      new Donations.PledgeMade(_.extend({}, this.pledgeData, {
+        sourceId: this.appealId,
+        version: 3
       }))
     ];
   };
 
   let appealWithAcceptedPledge = function () {
     return [
-      new Donations.AppealMade(_.extend({}, this.appealData, {
+      new Donations.AppealDrafted(_.extend({}, this.appealData, {
         sourceId: this.appealId,
         version: 1
       })),
-      new Donations.PledgeMade(_.extend({}, this.pledgeData, {
-        sourceId: this.appealId,
-        version: 2
-      })),
-      new Donations.PledgeAccepted(_.extend({}, this.pledgeData, {
-        sourceId: this.appealId,
-        version: 3
-      }))
-    ];
-  };
-
-  let appealWithFulfilledPledge = function () {
-    return [
       new Donations.AppealMade(_.extend({}, this.appealData, {
         sourceId: this.appealId,
-        version: 1
+        version: 2
       })),
       new Donations.PledgeMade(_.extend({}, this.pledgeData, {
         sourceId: this.appealId,
-        version: 2
-      })),
-      new Donations.PledgeAccepted(_.extend({}, this.pledgeData, {
-        sourceId: this.appealId,
         version: 3
       })),
-      new Donations.PledgeFulfilled(_.extend({}, this.pledgeData, {
+      new Donations.PledgeAccepted(_.extend({}, this.pledgeData, {
         sourceId: this.appealId,
         version: 4
       }))
     ];
   };
 
-  describe(`making an appeal`, function () {
+  let appealWithFulfilledPledge = function () {
+    return [
+      new Donations.AppealDrafted(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 1
+      })),
+      new Donations.AppealMade(_.extend({}, this.appealData, {
+        sourceId: this.appealId,
+        version: 2
+      })),
+      new Donations.PledgeMade(_.extend({}, this.pledgeData, {
+        sourceId: this.appealId,
+        version: 3
+      })),
+      new Donations.PledgeAccepted(_.extend({}, this.pledgeData, {
+        sourceId: this.appealId,
+        version: 4
+      })),
+      new Donations.PledgeFulfilled(_.extend({}, this.pledgeData, {
+        sourceId: this.appealId,
+        version: 5
+      }))
+    ];
+  };
+
+  describe(`drafting an appeal`, function () {
 
     it(`publishes an appeal added event`, function () {
 
       Donations.domain.test(Donations.Appeal)
         .given()
         .when([
-          new Donations.MakeAppeal(_.extend({}, this.appealData, {
+          new Donations.DraftAppeal(_.extend({}, this.appealData, {
             targetId: this.appealId
           }))
         ])
         .expect([
-          new Donations.AppealMade(_.extend({}, this.appealData, {
+          new Donations.AppealDrafted(_.extend({}, this.appealData, {
             sourceId: this.appealId,
             version: 1
           }))
+        ]);
+
+    });
+
+  });
+
+  describe(`making an appeal`, function () {
+
+    it(`publishes an appeal made event`, function () {
+
+      Donations.domain.test(Donations.Appeal)
+        .given(draftAppeal.call(this))
+        .when([
+          new Donations.MakeAppeal({
+            targetId: this.appealId
+          })
+        ])
+        .expect([
+          new Donations.AppealMade(_.extend({}, this.appealData, {
+            sourceId: this.appealId,
+            version: 2
+          }))
+        ]);
+
+    });
+
+    it(`only allows appeals to be made if currently a draft`, function () {
+
+      Donations.domain.test(Donations.Appeal)
+        .given(openAppeal.call(this))
+        .when(
+          new Donations.MakeAppeal({
+            targetId: this.appealId
+          })
+        )
+        .expect([
+          new Space.domain.Exception({
+            thrower: 'Donations.Appeal',
+            error: new Donations.InvalidAppealState('open','open')
+          })
+        ]);
+
+      Donations.domain.test(Donations.Appeal)
+        .given(closedAppeal.call(this))
+        .when(
+          new Donations.MakeAppeal({
+            targetId: this.appealId
+          })
+        )
+        .expect([
+          new Space.domain.Exception({
+            thrower: 'Donations.Appeal',
+            error: new Donations.InvalidAppealState('closed','open')
+          })
+        ]);
+
+    });
+
+  });
+
+  describe(`cancelling an appeal`, function () {
+
+    it(`cancels a draft appeal`, function () {
+
+      Donations.domain.test(Donations.Appeal)
+        .given(draftAppeal.call(this))
+        .when([
+          new Donations.CancelAppeal({
+            targetId: this.appealId
+          })
+        ])
+        .expect([
+          new Donations.AppealCancelled(_.extend({}, this.appealData, {
+            sourceId: this.appealId,
+            version: 2
+          }))
+        ]);
+
+    });
+
+    it(`does not allow cancelling of an open appeal`, function () {
+
+      Donations.domain.test(Donations.Appeal)
+        .given(openAppeal.call(this))
+        .when([
+          new Donations.CancelAppeal({
+            targetId: this.appealId
+          })
+        ])
+        .expect([
+          new Space.domain.Exception({
+            thrower: 'Donations.Appeal',
+            error: new Donations.InvalidAppealState('open','cancelled')
+          })
         ]);
 
     });

--- a/packages/domain/tests/appeals/appeal.tests.js
+++ b/packages/domain/tests/appeals/appeal.tests.js
@@ -455,7 +455,7 @@ describe(`Donations.Appeal`, function() {
           .expect([
             new Space.domain.Exception({
               thrower: 'Donations.Appeal',
-              error: new Donations.PledgeHasToBeAcceptedBeforeFulfilled()
+              error: new Donations.InvalidPledgeState('FulfillPledge','new')
             })
           ]);
         });
@@ -496,7 +496,7 @@ describe(`Donations.Appeal`, function() {
           .expect([
             new Space.domain.Exception({
               thrower: 'Donations.Appeal',
-              error: new Donations.FulfilledPledgeCannotBeDeclined()
+              error: new Donations.InvalidPledgeState('DeclinePledge','fulfilled')
             })
           ]);
 
@@ -538,7 +538,7 @@ describe(`Donations.Appeal`, function() {
           .expect([
             new Space.domain.Exception({
               thrower: 'Donations.Appeal',
-              error: new Donations.FulfilledPledgeCannotBeWrittenOff()
+              error: new Donations.InvalidPledgeState('WriteOffPledge','fulfilled')
             })
           ]);
 

--- a/packages/domain/tests/appeals/appeal.tests.js
+++ b/packages/domain/tests/appeals/appeal.tests.js
@@ -209,7 +209,7 @@ describe(`Donations.Appeal`, function() {
         .expect([
           new Space.domain.Exception({
             thrower: 'Donations.Appeal',
-            error: new Donations.InvalidAppealState('open','open')
+            error: new Donations.InvalidAppealState('MakeAppeal','open')
           })
         ]);
 
@@ -223,7 +223,7 @@ describe(`Donations.Appeal`, function() {
         .expect([
           new Space.domain.Exception({
             thrower: 'Donations.Appeal',
-            error: new Donations.InvalidAppealState('closed','open')
+            error: new Donations.InvalidAppealState('MakeAppeal','closed')
           })
         ]);
 
@@ -263,7 +263,7 @@ describe(`Donations.Appeal`, function() {
         .expect([
           new Space.domain.Exception({
             thrower: 'Donations.Appeal',
-            error: new Donations.InvalidAppealState('open','cancelled')
+            error: new Donations.InvalidAppealState('CancelAppeal','open')
           })
         ]);
 
@@ -355,7 +355,7 @@ describe(`Donations.Appeal`, function() {
         .expect([
           new Space.domain.Exception({
             thrower: 'Donations.Appeal',
-            error: new Donations.AppealNotOpenForNewPledges()
+            error: new Donations.InvalidAppealState('MakePledge','fulfilled')
           })
         ]);
 
@@ -369,7 +369,7 @@ describe(`Donations.Appeal`, function() {
         .expect([
           new Space.domain.Exception({
             thrower: 'Donations.Appeal',
-            error: new Donations.AppealNotOpenForNewPledges()
+            error: new Donations.InvalidAppealState('MakePledge','closed')
           })
         ]);
 
@@ -413,7 +413,7 @@ describe(`Donations.Appeal`, function() {
           .expect([
             new Space.domain.Exception({
               thrower: 'Donations.Appeal',
-              error: new Donations.AppealNotOpenToAcceptPledge()
+              error: new Donations.InvalidAppealState('AcceptPledge','fulfilled')
             })
           ]);
 
@@ -580,7 +580,7 @@ describe(`Donations.Appeal`, function() {
         .expect([
           new Space.domain.Exception({
             thrower: 'Donations.Appeal',
-            error: new Donations.FulfilledAppealCannotBeClosed()
+            error: new Donations.InvalidAppealState('CloseAppeal','fulfilled')
           })
         ]);
 
@@ -594,7 +594,7 @@ describe(`Donations.Appeal`, function() {
         .expect([
           new Space.domain.Exception({
             thrower: 'Donations.Appeal',
-            error: new Donations.FulfilledAppealCannotBeClosed()
+            error: new Donations.InvalidAppealState('CloseAppeal','closed')
           })
         ]);
 


### PR DESCRIPTION
All appeals start as a draft, and can then be either made (moves to
state of open) or cancelled.

Also standardises the concept of an invalid state error, to avoid the tedious setup of errors for this common violation.
