### PR TITLE
Feature/edit title description

### DIFF
--- a/packages/app/lib/i18n/de.i18n.json
+++ b/packages/app/lib/i18n/de.i18n.json
@@ -42,7 +42,7 @@
   },
   "appeals": {
     "draft": "<strong>Entwurf</strong>: Diese Spendenanfrage ist noch nicht öffentlich zu sehen",
-    "made": "Spendenanfrage veröffentlicht",
+    "open": "Spendenanfrage veröffentlicht",
     "make": "Spendenanfrage veröffentlichen"
   }
 }

--- a/packages/app/lib/i18n/en.i18n.json
+++ b/packages/app/lib/i18n/en.i18n.json
@@ -41,7 +41,7 @@
   },
   "appeals": {
     "draft": "<strong>Draft</strong>: Not yet public.",
-    "made": "Appeal made",
+    "open": "open",
     "make": "Make appeal to public"
   }
 }

--- a/packages/app/source/client/components/appeals-editor/edit/edit-appeal-form.js
+++ b/packages/app/source/client/components/appeals-editor/edit/edit-appeal-form.js
@@ -5,11 +5,19 @@ Donations.AppealForm.extend(Donations, 'EditAppealForm', {
   },
 
   _onSubmit() {
-    this.publish(new Donations.EditAppealDraftFormSubmitted(
-      _.extend(this._getValues(), {
-        appealId: this.appeal()._id
-      })
-    ));
+    if(this.appeal().state === 'draft') {
+      this.publish(new Donations.EditAppealDraftFormSubmitted(
+        _.extend(this._getValues(), {
+          appealId: this.appeal()._id
+        })
+      ));
+    } else if(this.appeal().state === 'open') {
+      this.publish(new Donations.EditAppealFormSubmitted(
+        _.extend(_.omit(this._getValues(), 'quantity'), {
+          appealId: this.appeal()._id
+        })
+      ));
+    }
   }
 
 });

--- a/packages/app/source/client/components/appeals-editor/list/edit-appeals-list-item.html
+++ b/packages/app/source/client/components/appeals-editor/list/edit-appeals-list-item.html
@@ -7,14 +7,14 @@
     <span class="title">{{title}}</span>
     <p class="description">{{description}}</p>
     <p class="state">
-      {{#if isMade}}
-        {{{i18n "appeals.made"}}}
+      {{#if isOpen}}
+        {{{i18n "appeals.open"}}}
       {{else}}
         {{{i18n "appeals.draft"}}}
       {{/if}}
     </p>
     <a href="#" class="edit">{{i18n "edit"}}</a>
-    {{#unless isMade}}
+    {{#unless isOpen}}
     | <a href="#" class="make">{{i18n "appeals.make"}}</a>
     {{/unless}}
   {{/if}}

--- a/packages/app/source/client/components/appeals-editor/list/edit-appeals-list-item.js
+++ b/packages/app/source/client/components/appeals-editor/list/edit-appeals-list-item.js
@@ -1,7 +1,7 @@
 Space.flux.BlazeComponent.extend(Donations, 'EditAppealsListItem', {
 
-  isMade() {
-    return this.data().state === 'made';
+  isOpen() {
+    return this.data().state === 'open';
   },
 
   reactiveVars() {

--- a/packages/app/source/client/controllers/appeals-controller.js
+++ b/packages/app/source/client/controllers/appeals-controller.js
@@ -14,7 +14,8 @@ Space.Object.extend(Donations, 'AppealsController', {
     return [{
       'Donations.AddAppealFormSubmitted': this._onAddAppealFormSubmitted,
       'Donations.EditAppealDraftFormSubmitted': this._onEditAppealDraftFormSubmitted,
-      'Donations.AppealMade': this._onAppealMade
+      'Donations.AppealMade': this._onAppealMade,
+      'Donations.EditAppealFormSubmitted': this._onEditAppealFormSubmitted
     }];
   },
 
@@ -40,6 +41,14 @@ Space.Object.extend(Donations, 'AppealsController', {
 
   _onAppealMade(event) {
     this.send(new Donations.MakeAppeal({ targetId: new Guid(event.appealId) }));
-  }
+  },
+
+  _onEditAppealFormSubmitted(event) {
+    this.send(new Donations.UpdateAppeal({
+      targetId: new Guid(event.appealId),
+      title: event.title,
+      description: event.description
+    }));
+  },
 
 });

--- a/packages/app/source/client/events/appeals.js
+++ b/packages/app/source/client/events/appeals.js
@@ -13,6 +13,12 @@ Space.messaging.define(Space.messaging.Event, 'Donations', {
     description: String
   },
 
+  EditAppealFormSubmitted: {
+    appealId: String,
+    title: String,
+    description: String
+  },
+
   AppealMade: {
     appealId: String
   }

--- a/packages/app/source/server/apis/appeals-api.js
+++ b/packages/app/source/server/apis/appeals-api.js
@@ -4,7 +4,8 @@ Space.messaging.Api.extend(Donations, 'AppealsApi', {
     return [{
       'Donations.DraftAppeal': this._draftAppeal,
       'Donations.UpdateAppealDraft': this._updateAppealDraft,
-      'Donations.MakeAppeal': this._makeAppeal
+      'Donations.MakeAppeal': this._makeAppeal,
+      'Donations.UpdateAppeal': this._makeAppeal
     }];
   },
 
@@ -17,6 +18,10 @@ Space.messaging.Api.extend(Donations, 'AppealsApi', {
   },
 
   _makeAppeal(context, command) {
+    this.commandBus.send(command);
+  },
+
+  _updateAppeal(context, command) {
     this.commandBus.send(command);
   }
 

--- a/packages/app/source/server/application.js
+++ b/packages/app/source/server/application.js
@@ -27,6 +27,11 @@ Donations.App = Space.Application.define('Donations.App', {
   onInitialize() {
     this.injector.map('Donations.Organizations').asStaticValue();
     this.injector.map('Donations.Appeals').asStaticValue();
+  },
+
+  onReset() {
+    this.injector.get('Donations.Organizations').remove({});
+    this.injector.get('Donations.Appeals').remove({});
   }
 
 });

--- a/packages/app/source/server/projections/appeals-projection.js
+++ b/packages/app/source/server/projections/appeals-projection.js
@@ -8,7 +8,8 @@ Space.eventSourcing.Projection.extend(Donations, 'AppealsProjection', {
     return [{
       'Donations.AppealDrafted': this._onAppealDrafted,
       'Donations.AppealDraftUpdated': this._onAppealDraftUpdated,
-      'Donations.AppealMade': this._onAppealMade
+      'Donations.AppealMade': this._onAppealMade,
+      'Donations.AppealUpdated': this._onAppealUpdated
     }];
   },
 
@@ -28,7 +29,13 @@ Space.eventSourcing.Projection.extend(Donations, 'AppealsProjection', {
   },
 
   _onAppealMade(event) {
-    this.appeals.update(event.sourceId.toString(), { $set: { state: 'made' } });
+    this.appeals.update(event.sourceId.toString(), { $set: { state: 'open' } });
+  },
+
+  _onAppealUpdated(event) {
+    this.appeals.update(event.sourceId.toString(), {
+      $set: { title: event.title, description: event.description }
+    });
   },
 
   _extractAppealDetails(event) {

--- a/packages/app/source/server/projections/appeals-projection.js
+++ b/packages/app/source/server/projections/appeals-projection.js
@@ -18,7 +18,7 @@ Space.eventSourcing.Projection.extend(Donations, 'AppealsProjection', {
       _id: event.sourceId.toString(),
       organizationId: event.organizationId.toString(),
       locationId: event.locationId.toString(),
-      state: 'drafted'
+      state: 'draft'
     }));
   },
 

--- a/packages/base/source/server/appeals/events.js
+++ b/packages/base/source/server/appeals/events.js
@@ -22,6 +22,11 @@ Space.messaging.define(Space.messaging.Event, `Donations`, {
     description: Match.Optional(String)
   },
 
+  AppealUpdated: {
+    title: String,
+    description: Match.Optional(String)
+  },
+
   AppealCancelled: {
     title: String,
     requiredQuantity: Quantity,

--- a/packages/base/source/shared/appeals/api-commands.js
+++ b/packages/base/source/shared/appeals/api-commands.js
@@ -16,6 +16,11 @@ Space.messaging.define(Space.messaging.Command, `Donations`, {
 
   MakeAppeal: {},
 
+  UpdateAppeal: {
+    title: String,
+    description: Match.Optional(String)
+  },
+
   CancelAppeal: {},
 
   CloseAppeal: {},

--- a/packages/domain/source/server/appeals/appeal-router.js
+++ b/packages/domain/source/server/appeals/appeal-router.js
@@ -7,6 +7,7 @@ Space.eventSourcing.Router.extend(Donations, `AppealRouter`, {
     Donations.UpdateAppealDraft,
     Donations.CancelAppeal,
     Donations.MakeAppeal,
+    Donations.UpdateAppeal,
     Donations.MakePledge,
     Donations.AcceptPledge,
     Donations.DeclinePledge,

--- a/packages/domain/source/server/appeals/appeal.js
+++ b/packages/domain/source/server/appeals/appeal.js
@@ -26,6 +26,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
       'Donations.UpdateAppealDraft': this._updateAppealDraft,
       'Donations.CancelAppeal': this._cancelAppeal,
       'Donations.MakeAppeal': this._makeAppeal,
+      'Donations.UpdateAppeal': this._updateAppeal,
       'Donations.MakePledge': this._makePledge,
       'Donations.AcceptPledge': this._acceptPledge,
       'Donations.DeclinePledge': this._declinePledge,
@@ -41,6 +42,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
       'Donations.AppealDraftUpdated': this._onAppealDraftUpdated,
       'Donations.AppealCancelled': this._onAppealCancelled,
       'Donations.AppealMade': this._onAppealMade,
+      'Donations.AppealUpdated': this._onAppealUpdated,
       'Donations.PledgeMade': this._onPledgeMade,
       'Donations.PledgeAccepted': this._onPledgeAccepted,
       'Donations.PledgeDeclined': this._onPledgeDeclined,
@@ -92,6 +94,15 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
       locationId: this.locationId,
       description: this.description
     }));
+  },
+
+  _updateAppeal(command) {
+    if (!this.hasState(this.STATES.open)) {
+      throw new Donations.InvalidAppealState(command.toString(), this._state);
+    }
+    this.record(new Donations.AppealUpdated(
+      this._eventPropsFromCommand(command)
+    ));
   },
 
   _makePledge(command) {
@@ -197,6 +208,10 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
 
   _onAppealMade() {
     this._state = this.STATES.open;
+  },
+
+  _onAppealDraftUpdated(event) {
+    this._assignFields(event);
   },
 
   _onPledgeMade(event) {

--- a/packages/domain/source/server/appeals/appeal.js
+++ b/packages/domain/source/server/appeals/appeal.js
@@ -210,7 +210,7 @@ Space.eventSourcing.Aggregate.extend(Donations, `Appeal`, {
     this._state = this.STATES.open;
   },
 
-  _onAppealDraftUpdated(event) {
+  _onAppealUpdated(event) {
     this._assignFields(event);
   },
 

--- a/packages/domain/tests/appeals/appeal.tests.js
+++ b/packages/domain/tests/appeals/appeal.tests.js
@@ -177,6 +177,31 @@ describe(`Donations.Appeal`, function() {
 
   });
 
+  describe(`updating the title and/or description a public appeal`, function() {
+
+    it(`publishes an appeal updated event`, function() {
+
+      Donations.domain.test(Donations.Appeal)
+        .given(openAppeal.call(this))
+        .when([
+          new Donations.UpdateAppeal({
+            targetId: this.appealId,
+            title: this.appealData.title,
+            description: this.appealData.description
+          })
+        ])
+        .expect([
+          new Donations.AppealUpdated({
+            sourceId: this.appealId,
+            title: this.appealData.title,
+            description: this.appealData.description
+          })
+        ]);
+
+    });
+
+  });
+
   describe(`cancelling an appeal`, function() {
 
     it(`cancels a draft appeal`, function() {


### PR DESCRIPTION
This implementation silently omits the requiredQty value during the update of an _open_ appeal as it's still not understood if we should allow this and we currently don't have an easy way to disable the field. The reason for leaving this out of the update is to avoid having to deal with existing pledges, which may be the real requirement here.
